### PR TITLE
♻️ small refactor of router.querys and 🐛 bug solving realted to usePersistent and coupons

### DIFF
--- a/public/locales/en/signup.json
+++ b/public/locales/en/signup.json
@@ -158,7 +158,8 @@
     "validate-email-title": "Verify your email",
     "validate-email-description": "We sent a confirmation email to: <strong>{{email}}</strong>, please check your email and click on the confirmation link.",
     "email-sent-to": "We sent you a confirmation email to {{email}}!",
-    "email-already-sent": "You have a pending invitation sent less than 1 day ago, check your email"
+    "email-already-sent": "You have a pending invitation sent less than 1 day ago, check your email",
+    "coupon-already-applied": "Coupon already applied"
   },
   "alert-message-validate-email": {
     "title": "Verify email",

--- a/public/locales/es/signup.json
+++ b/public/locales/es/signup.json
@@ -158,7 +158,8 @@
     "validate-email-title": "Verifique su correo electrónico",
     "validate-email-description": "Enviamos un correo electrónico de confirmación a: <strong>{{email}}</strong>, verifica tu correo electrónico y haz clic en el enlace de confirmación.",
     "email-sent-to": "Enviamos un correo electrónico de confirmación a {{email}}!",
-    "email-already-sent": "Tienes una invitación pendiente enviada hace menos de 1 día, revisa tu correo"
+    "email-already-sent": "Tienes una invitación pendiente enviada hace menos de 1 día, revisa tu correo",
+    "coupon-already-applied": "El cupón ya esta siendo aplicado"
   },
   "alert-message-validate-email": {
     "title": "Verificar correo electrónico",

--- a/src/common/components/MktShowPrices.jsx
+++ b/src/common/components/MktShowPrices.jsx
@@ -161,14 +161,9 @@ function MktShowPrices({ id, externalPlanProps, cohortId, title, gridColumn1, gr
           firstSectionTitle={t('subscription.upgrade-modal.subscription')}
           secondSectionTitle={t('subscription.upgrade-modal.finance')}
           handleUpgrade={(item) => {
-            const period = item?.period;
-
             const querys = parseQuerys({
               plan: item?.plan_slug,
               plan_id: item?.plan_id,
-              price: item?.price,
-              period,
-              cohort: cohortId,
               coupon: queryCoupon || coupon,
             });
             router.push(`/checkout${querys}`);

--- a/src/common/components/MktShowPrices.jsx
+++ b/src/common/components/MktShowPrices.jsx
@@ -164,6 +164,7 @@ function MktShowPrices({ id, externalPlanProps, cohortId, title, gridColumn1, gr
             const querys = parseQuerys({
               plan: item?.plan_slug,
               plan_id: item?.plan_id,
+              cohort: cohortId,
               coupon: queryCoupon || coupon,
             });
             router.push(`/checkout${querys}`);

--- a/src/common/components/PricingCard.jsx
+++ b/src/common/components/PricingCard.jsx
@@ -105,7 +105,6 @@ export default function PricingCard({ item, courseData, isFetching, relatedSubsc
   const alreadyHaveIt = relatedSubscription?.plans?.[0]?.slug === item?.plan_slug;
 
   const handlePlan = () => {
-    console.log('EJECUTE');
     const langPath = lang === 'en' ? '' : `/${lang}`;
     const qs = parseQuerys({
       plan: selectedFinancing?.plan_slug || item?.plan_slug,

--- a/src/common/components/PricingCard.jsx
+++ b/src/common/components/PricingCard.jsx
@@ -105,6 +105,7 @@ export default function PricingCard({ item, courseData, isFetching, relatedSubsc
   const alreadyHaveIt = relatedSubscription?.plans?.[0]?.slug === item?.plan_slug;
 
   const handlePlan = () => {
+    console.log('EJECUTE');
     const langPath = lang === 'en' ? '' : `/${lang}`;
     const qs = parseQuerys({
       plan: selectedFinancing?.plan_slug || item?.plan_slug,

--- a/src/common/components/PricingCard.jsx
+++ b/src/common/components/PricingCard.jsx
@@ -110,8 +110,6 @@ export default function PricingCard({ item, courseData, isFetching, relatedSubsc
     const qs = parseQuerys({
       plan: selectedFinancing?.plan_slug || item?.plan_slug,
       plan_id: selectedFinancing?.plan_id || item?.plan_id,
-      price: selectedFinancing?.price || item?.price,
-      period: selectedFinancing?.period || item?.period,
       coupon: coupon || queryCoupon,
       cohort: courseData?.cohort?.id,
     });

--- a/src/common/hooks/usePersistent.js
+++ b/src/common/hooks/usePersistent.js
@@ -22,6 +22,8 @@ const usePersistent = (key, initialValue) => {
 
 const usePersistentBySession = (key, initialValue) => {
   const getStoredValues = useMemo(() => {
+    if (typeof window === 'undefined') return initialValue;
+
     const item = isWindow ? window.sessionStorage.getItem(key) : null;
     if (item === null) return initialValue;
 
@@ -34,14 +36,12 @@ const usePersistentBySession = (key, initialValue) => {
 
   const [storedValue, setStoredValue] = useState(getStoredValues);
 
+  console.log(storedValue);
+
   const setValue = (value) => {
-    try {
-      setStoredValue(value);
-      const valueToStore = typeof value === 'object' ? JSON.stringify(value) : value;
-      window.sessionStorage.setItem(key, valueToStore);
-    } catch (error) {
-      console.error('usePersistent_error:', error);
-    }
+    setStoredValue(value);
+    const valueToStore = typeof value === 'object' ? JSON.stringify(value) : value;
+    window.sessionStorage.setItem(key, valueToStore);
   };
   return [storedValue, setValue];
 };

--- a/src/common/hooks/usePersistent.js
+++ b/src/common/hooks/usePersistent.js
@@ -23,9 +23,13 @@ const usePersistent = (key, initialValue) => {
 const usePersistentBySession = (key, initialValue) => {
   const getStoredValues = useMemo(() => {
     const item = isWindow ? window.sessionStorage.getItem(key) : null;
-    const isObject = typeof item === 'object';
-    const objectValue = JSON.parse(item) || initialValue;
-    return isObject ? objectValue : item || initialValue;
+    if (item === null) return initialValue;
+
+    if (item.startsWith('{') || item.startsWith('[')) {
+      return JSON.parse(item);
+    }
+
+    return item;
   }, [key, initialValue]);
 
   const [storedValue, setStoredValue] = useState(getStoredValues);
@@ -33,7 +37,8 @@ const usePersistentBySession = (key, initialValue) => {
   const setValue = (value) => {
     try {
       setStoredValue(value);
-      window.sessionStorage.setItem(key, JSON.stringify(value));
+      const valueToStore = typeof value === 'object' ? JSON.stringify(value) : value;
+      window.sessionStorage.setItem(key, valueToStore);
     } catch (error) {
       console.error('usePersistent_error:', error);
     }

--- a/src/common/hooks/usePersistent.js
+++ b/src/common/hooks/usePersistent.js
@@ -41,7 +41,7 @@ const usePersistentBySession = (key, initialValue) => {
     const valueToStore = typeof value === 'object' ? JSON.stringify(value) : value;
     window.sessionStorage.setItem(key, valueToStore);
   };
-  return [storedValue, setValue];
+  return [storedValue !== undefined ? storedValue : initialValue, setValue];
 };
 
 export {

--- a/src/common/hooks/usePersistent.js
+++ b/src/common/hooks/usePersistent.js
@@ -36,8 +36,6 @@ const usePersistentBySession = (key, initialValue) => {
 
   const [storedValue, setStoredValue] = useState(getStoredValues);
 
-  console.log(storedValue);
-
   const setValue = (value) => {
     setStoredValue(value);
     const valueToStore = typeof value === 'object' ? JSON.stringify(value) : value;

--- a/src/js_modules/checkout/ChooseYourClass.jsx
+++ b/src/js_modules/checkout/ChooseYourClass.jsx
@@ -87,6 +87,7 @@ function ChooseYourClass({
           };
         });
 
+        //SI NO AÑADO COHORTS ENTONCES TENGO QUE SABER LA IMPORTANCIA
         const filteredCohorts = Array.isArray(formatedData) ? formatedData.filter((item) => item?.never_ends === false) : null;
         setCohorts({
           cohorts: filteredCohorts,

--- a/src/js_modules/checkout/ChooseYourClass.jsx
+++ b/src/js_modules/checkout/ChooseYourClass.jsx
@@ -87,7 +87,6 @@ function ChooseYourClass({
           };
         });
 
-        //SI NO AÑADO COHORTS ENTONCES TENGO QUE SABER LA IMPORTANCIA
         const filteredCohorts = Array.isArray(formatedData) ? formatedData.filter((item) => item?.never_ends === false) : null;
         setCohorts({
           cohorts: filteredCohorts,

--- a/src/js_modules/checkout/Summary.jsx
+++ b/src/js_modules/checkout/Summary.jsx
@@ -194,8 +194,6 @@ function Summary() {
         query: {
           ...router.query,
           plan_id: selectedPlanCheckoutData?.plan_id,
-          price: selectedPlanCheckoutData?.price,
-          period: selectedPlanCheckoutData?.period,
         },
       });
     } else {

--- a/src/pages/bootcamp/[course_slug].jsx
+++ b/src/pages/bootcamp/[course_slug].jsx
@@ -207,10 +207,7 @@ function Page({ data }) {
     plan: featuredPlanToEnroll?.plan_slug,
     plan_id: featuredPlanToEnroll?.plan_id,
     has_available_cohorts: planData?.has_available_cohorts,
-    price: featuredPlanToEnroll?.price,
-    period: featuredPlanToEnroll?.period,
-    cohort: cohortId,
-  }) : `?plan=${data?.plan_slug}&cohort=${cohortId}`;
+  }) : `?plan=${data?.plan_slug}`;
 
   const getPlanPrice = () => {
     if (featuredPlanToEnroll?.plan_slug) {

--- a/src/pages/bootcamp/[course_slug].jsx
+++ b/src/pages/bootcamp/[course_slug].jsx
@@ -207,7 +207,8 @@ function Page({ data }) {
     plan: featuredPlanToEnroll?.plan_slug,
     plan_id: featuredPlanToEnroll?.plan_id,
     has_available_cohorts: planData?.has_available_cohorts,
-  }) : `?plan=${data?.plan_slug}`;
+    cohort: cohortId,
+  }) : `?plan=${data?.plan_slug}&cohort=${cohortId}`;
 
   const getPlanPrice = () => {
     if (featuredPlanToEnroll?.plan_slug) {

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -100,6 +100,8 @@ function Checkout() {
 
   const cohorts = cohortsData?.cohorts;
 
+  console.log(checkoutData);
+
   axiosInstance.defaults.headers.common['Accept-Language'] = router.locale;
   const { user, isAuthenticated, isLoading } = useAuth();
   const { userSession } = useSession();
@@ -162,6 +164,23 @@ function Checkout() {
   };
 
   const handleCoupon = (coupons, actions) => {
+    // Verificar si el cupón ingresado ya está aplicado
+    const alreadyAppliedCoupon = selfAppliedCoupon?.slug === discountCode || selfAppliedCoupon?.slug === couponValue;
+
+    if (alreadyAppliedCoupon) {
+      toast({
+        position: 'top',
+        title: t('alert-message:coupon-already-applied'),
+        status: 'info',
+        duration: 4000,
+        isClosable: true,
+      });
+      if (actions) {
+        actions.setSubmitting(false);
+      }
+      return;
+    }
+
     bc.payment({
       coupons: [coupons || discountCode],
       plan: planFormated,

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -113,6 +113,8 @@ function Checkout() {
   const accessToken = getStorageItem('accessToken');
   const tokenExists = accessToken !== null && accessToken !== undefined && accessToken.length > 5;
   const { coupon: couponQuery } = query;
+  const { course } = router.query;
+
   const [coupon] = usePersistentBySession('coupon', '');
 
   const couponValue = useMemo(() => {
@@ -121,7 +123,6 @@ function Checkout() {
     return couponString || formatedCouponQuery;
   }, [coupon, couponQuery]);
 
-  const { course } = router.query;
   const courseChoosed = course;
 
   const queryPlanExists = planFormated !== undefined && planFormated?.length > 0;

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -100,8 +100,6 @@ function Checkout() {
 
   const cohorts = cohortsData?.cohorts;
 
-  console.log(checkoutData);
-
   axiosInstance.defaults.headers.common['Accept-Language'] = router.locale;
   const { user, isAuthenticated, isLoading } = useAuth();
   const { userSession } = useSession();
@@ -116,6 +114,7 @@ function Checkout() {
   const tokenExists = accessToken !== null && accessToken !== undefined && accessToken.length > 5;
   const { coupon: couponQuery } = query;
   const { course } = router.query;
+  const courseChoosed = course;
 
   const [coupon] = usePersistentBySession('coupon', '');
 
@@ -124,8 +123,6 @@ function Checkout() {
     const couponString = coupon?.replaceAll('"', '') || '';
     return couponString || formatedCouponQuery;
   }, [coupon, couponQuery]);
-
-  const courseChoosed = course;
 
   const queryPlanExists = planFormated !== undefined && planFormated?.length > 0;
   const queryMentorshipServiceSlugExists = mentorshipServiceSetSlug && mentorshipServiceSetSlug?.length > 0;
@@ -164,13 +161,12 @@ function Checkout() {
   };
 
   const handleCoupon = (coupons, actions) => {
-    // Verificar si el cupón ingresado ya está aplicado
     const alreadyAppliedCoupon = selfAppliedCoupon?.slug === discountCode || selfAppliedCoupon?.slug === couponValue;
 
     if (alreadyAppliedCoupon) {
       toast({
         position: 'top',
-        title: t('alert-message:coupon-already-applied'),
+        title: t('signup:alert-message.coupon-already-applied'),
         status: 'info',
         duration: 4000,
         isClosable: true,


### PR DESCRIPTION
### Issue: [#7770](https://github.com/breatheco-de/breatheco-de/issues/7770)

### Bug Descriptions:

#### Bug 1
If a course already has a coupon applied (e.g., `summer-25`), the system currently allows users to apply the same coupon again, resulting in an additional discount. This behavior is incorrect. Instead, with the fix, the system should display a toast message notifying the user that the coupon has already been applied.

#### Bug 2
When using a `coupon` in the URL's query string, it is saved in `usePersistent` as a string. If a subsequent transaction is attempted, the `usePersistent` logic triggers and parses the string, causing an exponential duplication issue (e.g., returning `/'string'/`). 

This occurs because `JSON.stringify` is designed to serialize objects, arrays, and other data types. When applied directly to a simple string (e.g., `"summer-25"`), it converts the string into a JSON-valid string that includes additional quotes, causing unintended behavior.