### PR TITLE
:ambulance: quick hotfix to avoid toast in checkout

### DIFF
--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -161,7 +161,7 @@ function Checkout() {
   };
 
   const handleCoupon = (coupons, actions) => {
-    const alreadyAppliedCoupon = (selfAppliedCoupon?.slug === discountCode && selfAppliedCoupon?.slug !== undefined) || (selfAppliedCoupon?.slug === couponValue && selfAppliedCoupon?.slug !== undefined);
+    const alreadyAppliedCoupon = (selfAppliedCoupon?.slug && selfAppliedCoupon?.slug === discountCode) || (selfAppliedCoupon?.slug && selfAppliedCoupon?.slug === couponValue);
 
     if (alreadyAppliedCoupon) {
       toast({

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -161,7 +161,7 @@ function Checkout() {
   };
 
   const handleCoupon = (coupons, actions) => {
-    const alreadyAppliedCoupon = selfAppliedCoupon?.slug === discountCode || selfAppliedCoupon?.slug === couponValue;
+    const alreadyAppliedCoupon = (selfAppliedCoupon?.slug === discountCode && selfAppliedCoupon?.slug !== undefined) || (selfAppliedCoupon?.slug === couponValue && selfAppliedCoupon?.slug !== undefined);
 
     if (alreadyAppliedCoupon) {
       toast({


### PR DESCRIPTION
when doing a checkout, if `alreadyAppliedCoupon` is undefined it shows the toast. Now if it is undefined it will not show it