### PR TITLE
🐛  users cannot send projects cause of cohort being an object

### DIFF
--- a/src/common/hooks/useModuleHandler.js
+++ b/src/common/hooks/useModuleHandler.js
@@ -71,10 +71,11 @@ function useModuleHandler() {
         delivered_at: new Date().toISOString(),
       };
 
-      const { cohort, ...taskData } = taskToUpdate;
+      const { cohort: { id }, ...taskData } = taskToUpdate;
+      const updatedTask = { ...taskData, cohort: id };
 
       try {
-        const response = await bc.todo({}).update(taskData);
+        const response = await bc.todo({}).update(updatedTask);
         // verify if form is equal to the response
         if (response.data.github_url === projectUrl) {
           const keyIndex = taskTodo.findIndex((x) => x.id === task.id);

--- a/src/common/hooks/useModuleHandler.js
+++ b/src/common/hooks/useModuleHandler.js
@@ -68,11 +68,13 @@ function useModuleHandler() {
         task_status: taskStatus || toggleStatus,
         github_url: projectUrl,
         revision_status: 'PENDING',
-        delivered_at: new Date(),
+        delivered_at: new Date().toISOString(),
       };
 
+      const { cohort, ...taskData } = taskToUpdate;
+
       try {
-        const response = await bc.todo({}).update(taskToUpdate);
+        const response = await bc.todo({}).update(taskData);
         // verify if form is equal to the response
         if (response.data.github_url === projectUrl) {
           const keyIndex = taskTodo.findIndex((x) => x.id === task.id);

--- a/src/common/hooks/useModuleHandler.js
+++ b/src/common/hooks/useModuleHandler.js
@@ -71,8 +71,11 @@ function useModuleHandler() {
         delivered_at: new Date().toISOString(),
       };
 
-      const { cohort: { id }, ...taskData } = taskToUpdate;
-      const updatedTask = { ...taskData, cohort: id };
+      const { cohort, ...taskData } = taskToUpdate;
+      const updatedTask = {
+        ...taskData,
+        cohort: typeof cohort === 'object' && cohort !== null ? cohort.id : cohort,
+      };
 
       try {
         const response = await bc.todo({}).update(updatedTask);
@@ -121,7 +124,7 @@ function useModuleHandler() {
   };
 
   const startDay = async ({
-    newTasks, label, customHandler = () => {},
+    newTasks, label, customHandler = () => { },
   }) => {
     try {
       const response = await bc.todo({}).add(newTasks);


### PR DESCRIPTION
When updating a project, I encountered an error related to the cohort field. The error message is:

"Incorrect type. Expected pk value, received dict."

This happens because the cohort field in the payload of the request is an object. The object contains multiple fields such as id, name, and slug. However, the system expects a primary key value (a single numeric ID) rather than the full object. This bug does not happen with lessons or exercises because the cohort field is not included in the payload.

Fix: To resolve the issue, I extracted only the id from the cohort object before sending the request. I replaced the full cohort object with its id so that the payload now contains only the primary key value, which the system expects.
