### PR TITLE
🐛  fix related to duplicated assets

### DIFF
--- a/src/common/components/ReviewModal/index.jsx
+++ b/src/common/components/ReviewModal/index.jsx
@@ -413,7 +413,6 @@ function ReviewModal({ isExternal, externalFiles, isOpen, isStudent, externalDat
         const respData = await fileResp.data;
         setFileData(respData);
       }
-      if (typeof assetData?.delivery_formats === 'string' && assetData?.delivery_formats.includes('url')) setFileData([]);
       callback();
     }
   };

--- a/src/common/components/ReviewModal/index.jsx
+++ b/src/common/components/ReviewModal/index.jsx
@@ -413,6 +413,7 @@ function ReviewModal({ isExternal, externalFiles, isOpen, isStudent, externalDat
         const respData = await fileResp.data;
         setFileData(respData);
       }
+      if (typeof assetData?.delivery_formats === 'string' && assetData?.delivery_formats.includes('url')) setFileData([]);
       callback();
     }
   };

--- a/src/pages/syllabus/[cohortSlug]/[lesson]/[lessonSlug]/index.jsx
+++ b/src/pages/syllabus/[cohortSlug]/[lesson]/[lessonSlug]/index.jsx
@@ -387,6 +387,7 @@ function SyllabusContent() {
     setIpynbHtmlUrl(null);
     setCurrentBlankProps(null);
     setSubTasks([]);
+    setFileData([]);
   };
 
   const onClickAssignment = (e, item) => {


### PR DESCRIPTION
### Issue: https://github.com/breatheco-de/breatheco-de/issues/8299

## Case 2
Looks like the picture comes from a project where there is no need to upload a file (confirmed with Ehiber).

## Case 1
i could not reproduce the exact picture in the assigments view, looking at the code, it even shouldn't be possible to have the "file list sent" part that appears in the picture.

it all starts in the `assigments` view (`src\pages\cohort\[cohortSlug]\assignments.jsx`), where you can see that we have the section projects:
```
{currentView === 1 && (
          <Projects
            updpateAssignment={updpateAssignment}
            loadStatus={loadStatus}
            syllabusData={syllabusData}
            getFilterAssignments={getFilterAssignments}
            selectedCohort={selectedCohort}
          />
        )}
```

if we move further to that component we can see that all the rows showed in that section comes from:
```
<InfiniteScroll
          data={contextState.allTasks}
          loadMore={loadMore}
          currentPage={currentPage}
          pageCount={pageCount}
          hasMore={hasMore}
        >
          <ProjectsRows
            updpateAssignment={updpateAssignment}
            syllabusData={syllabusData}
            loadStatus={loadStatus}
            filteredTasks={filteredTasks}
          />
</InfiniteScroll>
```

in `ProjectRows` component the button that opens the bug related modal is:
```
<ButtonHandler
    currentTask={task}
    contextState={contextState}
    updpateAssignment={updpateAssignment}
/>
```

looking at the button handler component the modal should be openned following this conditions:
```
if (statusConditional.delivered) {
      return (
        <ReviewHandler currentTask={currentTask} projectLink={projectLink} updpateAssignment={updpateAssignment} />
      );
    }
```

moving forward to the `ReviewHandler` component that ends up rendering the `ReviewModalComponent`, the only way to show the "file list sent" part is having fileData which can only be set using the prop `externalFiles` or through the function `getAssetData` which can only be used when the user is a student.

Teachers should be able to review files through this option:
![image](https://github.com/user-attachments/assets/acf2cf3b-0109-47c9-bb8d-b5a039c9052a)

However i could reproduce the bug as a student following this steps:

- [ ] First, I submitted the project Network Troubleshooting Packet Tracer, which requires uploading a file instead of providing a GitHub link.
- [ ] After that, I submitted the project Getting to Know GNU/Linux Distributions, which does not require uploading any files, but instead, it involves submitting a Google presentation url.
- [ ] When clicking "Update Project Delivery" on the Network Troubleshooting Packet Tracer project (inside the project view where you see the project description), you can see the uploaded files for that asset.
- [ ] Then, if you go back to the GNU/Linux Distributions project and click "Update Project Delivery", the file(s) uploaded from the previous project appears there.

