### PR TITLE
🐛  show share modal when delivering a project

### DIFF
--- a/src/common/components/PopoverTaskHandler.jsx
+++ b/src/common/components/PopoverTaskHandler.jsx
@@ -503,6 +503,7 @@ function PopoverTaskHandler({
         isOpen={settingsOpen}
         onClose={handleCloseFile}
         trigger="click"
+        placement="top-start"
       >
         <PopoverTrigger>
           <Tooltip label={textAndIcon.text} placement="top">
@@ -544,6 +545,7 @@ function PopoverTaskHandler({
       isOpen={settingsOpen}
       onClose={handleCloseFile}
       trigger="click"
+      placement="top-start"
     >
 
       <PopoverTrigger>

--- a/src/pages/syllabus/[cohortSlug]/[lesson]/[lessonSlug]/index.jsx
+++ b/src/pages/syllabus/[cohortSlug]/[lesson]/[lessonSlug]/index.jsx
@@ -504,7 +504,7 @@ function SyllabusContent() {
         translations: [],
       });
     };
-  }, [router, lessonSlug, cohortSession, sortedAssignments]);
+  }, [router, lessonSlug, cohortSession, sortedAssignments.length]);
 
   useEffect(() => {
     const currentSyllabus = sortedAssignments.find((l) => l.id === currentSelectedModule);


### PR DESCRIPTION
### Issue: https://github.com/breatheco-de/breatheco-de/issues/8665

### Description
The bug occurs due to the variable changed on the pr because, when we send a project, sortedAssigments is updated because de project becomes delivered, however the variable is needed as we need the sortedAssigments to get de assets.

removing the variable will lead to a bug when accessing the page direct from the url (or refreshing the page) as the sortedAssigments are not obtained in the first render, then the readme will stay loading until we do some sort of re-rendering