### PR TITLE
:bug: fix on checkout when previusly buying basic plan

### DIFF
--- a/src/pages/checkout/[service_type]/[service_slug].jsx
+++ b/src/pages/checkout/[service_type]/[service_slug].jsx
@@ -132,7 +132,6 @@ function ServiceSlug() {
     }
   }, [isAuthenticated, areSubscriptionsFetched, router.locale]);
 
-  // eslint-disable-next-line arrow-body-style
   useEffect(() => {
     if (!allowedServiceTypes.includes(service_type)) router.push('/404');
     return () => {

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -330,10 +330,9 @@ function Checkout() {
                                           <Text fontSize="md" flex="1" color={option.plan_id === selectedPlan?.plan_id ? useColorModeValue('#25BF6C', 'green') : 'auto'}>
                                             {originalPlan.hasSubscriptionMethod
                                               ? (
-                                                `${handlePriceTextWithCoupon(option.priceText, allCoupons, originalPlan.plans)} / ${option.title}${
-                                                  option.pricePerMonthText
-                                                    ? `, (${handlePriceTextWithCoupon(option.pricePerMonthText, allCoupons, originalPlan.plans)}${t('signup:info.per-month')})`
-                                                    : ''
+                                                `${handlePriceTextWithCoupon(option.priceText, allCoupons, originalPlan.plans)} / ${option.title}${option.pricePerMonthText
+                                                  ? `, (${handlePriceTextWithCoupon(option.pricePerMonthText, allCoupons, originalPlan.plans)}${t('signup:info.per-month')})`
+                                                  : ''
                                                 }`
                                               )
                                               : `${handlePriceTextWithCoupon(option.priceText, allCoupons, originalPlan.plans)} / ${option.title}`}

--- a/src/pages/checkout/useCheckout.js
+++ b/src/pages/checkout/useCheckout.js
@@ -22,6 +22,7 @@ const useCheckout = () => {
   const {
     state, handleStep, setLoader,
     setSelectedPlan, setCheckingData, setPlanData,
+    restartSignup,
   } = signupAction();
   const {
     stepsEnum, getSelfAppliedCoupon,
@@ -299,7 +300,7 @@ const useCheckout = () => {
     if (!isAuthenticated && !accessToken) {
       setLoader('plan', false);
     }
-  }, [isAuthenticated, router.locale]);
+  }, [isAuthenticated, router.locale, planData]);
 
   useEffect(() => {
     if (!userSelectedPlan || !planData) return;
@@ -461,6 +462,8 @@ const useCheckout = () => {
 
     return null;
   };
+
+  useEffect(() => () => restartSignup(), []);
 
   return {
     couponError,


### PR DESCRIPTION
### Issue: https://github.com/breatheco-de/breatheco-de/issues/9208

### Tests:
1. Comprar plan gratis y luego comprar plan pago - ✅ Success
   - El flujo de autenticación funciona correctamente
   - Se muestra correctamente el formulario de pago para el segundo plan
   - El estado se reinicia apropiadamente entre compras

2. Comprar plan pago y luego otro plan pago - ✅ Success
   - El flujo de autenticación funciona correctamente
   - Se muestra correctamente el formulario de pago para el segundo plan
   - Los métodos de pago del usuario se actualizan correctamente con el último método usado
   - El estado se reinicia apropiadamente entre compras

3. Comprar plan pago y luego plan gratis - ✅ Success
   - El flujo de autenticación funciona correctamente
   - Se procesa correctamente el plan gratuito sin mostrar el formulario de pago
   - El estado se reinicia apropiadamente entre compras
   - Side test: Al entrar al landing del bootcamp, se puede acceder al bootcamp haciendo clic en "join cohort"

4. Acceder al checkout directamente por URL después de comprar plan gratis - ✅ Success
   - El estado se reinicia correctamente
   - Se muestra el formulario de pago para el nuevo plan
   - La autenticación funciona correctamente