### PR TITLE
🐛  closing toast and no more than 3 toast appear at the same time

### DIFF
--- a/src/hooks/useCustomToast.jsx
+++ b/src/hooks/useCustomToast.jsx
@@ -29,9 +29,9 @@ const useCustomToast = () => {
     actions = null,
     isClosable = true,
   }) => {
-    // Limitar a máximo 3 toasts activos
+    // Limit to 3 the number of active toast (to avoid overwellming the ui)
     if (activeToasts.size >= 3) {
-      // Cerrar el toast más antiguo
+      // Close oldest toast
       const oldestToast = Array.from(activeToasts)[0];
       closeToast(oldestToast);
     }


### PR DESCRIPTION
### Issue: https://github.com/breatheco-de/breatheco-de/issues/9227

### Additional adding:

To avoid overwellming the ui with toast, the amount of active toast was limited to 3