### PR TITLE
:chart_with_upwards_trend: Added report analytic for abandoned checkout

### DIFF
--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -138,8 +138,8 @@ function Checkout() {
   useEffect(() => {
     const handleExit = (eventOrUrl) => {
       if (
-        (typeof eventOrUrl === 'string' && !eventOrUrl.startsWith('/checkout')) ||
-        typeof eventOrUrl === 'object'
+        (typeof eventOrUrl === 'string' && !eventOrUrl.startsWith('/checkout'))
+        || typeof eventOrUrl === 'object'
       ) {
         reportDatalayer({
           dataLayer: {
@@ -154,19 +154,19 @@ function Checkout() {
             agent: getBrowserInfo(),
           },
         });
-          
       }
     };
-  
+
     if (!isPaymentSuccess) {
       window.addEventListener('beforeunload', handleExit);
       router.events.on('routeChangeStart', handleExit);
-  
+
       return () => {
         window.removeEventListener('beforeunload', handleExit);
         router.events.off('routeChangeStart', handleExit);
       };
     }
+    return undefined;
   }, [router, isPaymentSuccess]);
 
   return (

--- a/src/pages/checkout/index.jsx
+++ b/src/pages/checkout/index.jsx
@@ -28,7 +28,7 @@ import ContactInformation from '../../components/Checkout/ContactInformation';
 import Summary from '../../components/Checkout/Summary';
 import PaymentInfo from '../../components/Checkout/PaymentInfo';
 import Stepper from '../../components/Checkout/Stepper';
-import { getBrowserInfo, removeSessionStorageItem } from '../../utils';
+import { removeSessionStorageItem } from '../../utils';
 import signupAction from '../../store/actions/signupAction';
 import LoaderScreen from '../../components/LoaderScreen';
 import ModalInfo from '../../components/ModalInfo';
@@ -40,8 +40,6 @@ import Icon from '../../components/Icon';
 import AcordionList from '../../components/AcordionList';
 import useCustomToast from '../../hooks/useCustomToast';
 import { handlePriceTextWithCoupon } from '../../utils/getPriceWithDiscount';
-import useAuth from '../../hooks/useAuth';
-import { reportDatalayer } from '../../utils/requests';
 
 export const getStaticProps = async ({ locale, locales }) => {
   const t = await getT(locale, 'signup');
@@ -75,7 +73,6 @@ export const getStaticProps = async ({ locale, locales }) => {
 };
 
 function Checkout() {
-  const { user } = useAuth();
   const { t } = useTranslation('signup');
   const router = useRouter();
   const {
@@ -134,40 +131,6 @@ function Checkout() {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [isOpenned]);
-
-  useEffect(() => {
-    const handleExit = (eventOrUrl) => {
-      if (
-        (typeof eventOrUrl === 'string' && !eventOrUrl.startsWith('/checkout'))
-        || typeof eventOrUrl === 'object'
-      ) {
-        reportDatalayer({
-          dataLayer: {
-            event: 'checkout_abandonment',
-            user: user?.email,
-            plan: selectedPlan?.title,
-            checkout_id: checkingData?.id,
-            checkout_status: paymentStatus,
-            checkout_date: new Date().toISOString(),
-            checkout_amount: selectedPlan?.price,
-            step: stepIndex,
-            agent: getBrowserInfo(),
-          },
-        });
-      }
-    };
-
-    if (!isPaymentSuccess) {
-      window.addEventListener('beforeunload', handleExit);
-      router.events.on('routeChangeStart', handleExit);
-
-      return () => {
-        window.removeEventListener('beforeunload', handleExit);
-        router.events.off('routeChangeStart', handleExit);
-      };
-    }
-    return undefined;
-  }, [router, isPaymentSuccess]);
 
   return (
     <Box p={{ base: '0 0', md: '0' }} background={backgroundColor3} position="relative" minHeight={loader.plan ? '727px' : 'auto'}>


### PR DESCRIPTION
The following scenarios are covered:

- **Closing the browser tab or window**
- **Navigating away from the checkout flow (to a different route)**

### How it works

- We add event listeners for both `beforeunload` (tab/window close or reload) and Next.js `routeChangeStart` (route navigation).

- The handler checks:

    - If the event is a route change, it only triggers the logic if the new route does **not** start with `/checkout` (i.e., the user is leaving the checkout flow).
    - If the event is a `beforeunload`, the logic is always triggered (since it’s not possible to distinguish between reload and close).

- The logic is not executed if the payment was successful.

### Limitations
- Due to browser limitations, it is **not possible** to distinguish between a page reload and a tab/window close. Both will trigger the same logic.

### Issue: https://github.com/breatheco-de/breatheco-de/issues/9304