### PR TITLE
change to solve bug about wrong delivery format

### DIFF
--- a/src/components/AssignmentButton/index.jsx
+++ b/src/components/AssignmentButton/index.jsx
@@ -3,7 +3,7 @@ import {
 } from '@chakra-ui/react';
 import useTranslation from 'next-translate/useTranslation';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import useStyle from '../../hooks/useStyle';
 import Icon from '../Icon';
 import ProjectSubmitButton from './ProjectSubmitButton';
@@ -31,6 +31,12 @@ function AssignmentButton({
   const [currentAsset, setCurrentAsset] = useState(currentAssetData);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [fileData, setFileData] = useState(null);
+
+  useEffect(() => {
+    if (currentAssetData?.id !== currentAsset?.id) {
+      setCurrentAsset(currentAssetData);
+    }
+  }, [currentAssetData]);
 
   const [loaders, setLoaders] = useState({
     isFetchingCommitFiles: false,


### PR DESCRIPTION
Looks like when sending a project the delivery button was not updating the asset, thus it was showing the delivery format of the previous asset, this is probably the reason of this bug

### Issue: https://github.com/breatheco-de/breatheco-de/issues/9379