### PR TITLE
Enhance User Modal: Immediate Box-Shadow Visibility and Improved Divider Contrast

### DIFF
--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -48,7 +48,7 @@ function Navbar({ translations, pageProps }) {
   const { toggleColorMode } = useColorMode();
   const fontColor = useColorModeValue('black', 'gray.200');
   const isMobile = useBreakpointValue({ base: true, lg: false });
-  const { hexColor, colorMode, reverseColorMode, borderColor, navbarBackground } = useStyle();
+  const { hexColor, colorMode, reverseColorMode, borderColor, borderColor2, navbarBackground } = useStyle();
 
   const existsCohortWithoutAvailableAsSaas = cohorts.some((c) => c?.available_as_saas === false);
   const existsPaidSubscription = allSubscriptions.some((sb) => sb?.invoices?.[0]?.amount > 0);
@@ -367,7 +367,7 @@ function Navbar({ translations, pageProps }) {
 
                 <PopoverContent
                   border={0}
-                  boxShadow="2xl"
+                  style={{ boxShadow: 'var(--chakra-shadows-2xl) !important' }}
                   rounded="md"
                   width={{ base: '100%', md: 'auto' }}
                   minW={{ base: 'auto', md: 'md' }}
@@ -398,7 +398,7 @@ function Navbar({ translations, pageProps }) {
                     <Flex
                       borderTop={2}
                       borderStyle="solid"
-                      borderColor={borderColor}
+                      borderColor={borderColor2}
                       alignItems="center"
                       padding="1rem 0rem"
                     >
@@ -419,7 +419,7 @@ function Navbar({ translations, pageProps }) {
                     <Flex
                       borderTop={2}
                       borderStyle="solid"
-                      borderColor={borderColor}
+                      borderColor={borderColor2}
                       alignItems="center"
                       padding="1rem 0rem"
                     >


### PR DESCRIPTION
**Description:**

- Replaced the Chakra prop `boxShadow="2xl"` with an inline style `style={{ boxShadow: 'var(--chakra-shadows-2xl) !important' }}` in the `PopoverContent` component to ensure the box-shadow is visible as soon as the modal opens.
- Updated the variable used for the divider border color inside the modal, changing from `borderColor={borderColor}` to `borderColor={borderColor2}` in the `Flex` components, to improve contrast and visibility, especially in dark mode.

These changes enhance the visual appearance of the user modal, ensuring that the box-shadow and dividers are consistent and visible in all color modes.

**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9395