### PR TITLE
Fix: Use Chakra Prop for Box-Shadow in User Modal

### DIFF
--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -367,7 +367,7 @@ function Navbar({ translations, pageProps }) {
 
                 <PopoverContent
                   border={0}
-                  style={{ boxShadow: 'var(--chakra-shadows-2xl) !important' }}
+                  boxShadow="2xl !important"
                   rounded="md"
                   width={{ base: '100%', md: 'auto' }}
                   minW={{ base: 'auto', md: 'md' }}


### PR DESCRIPTION
**Description:**

- Replaced the inline style for the box-shadow with the Chakra prop `boxShadow="2xl !important"` in the `PopoverContent` component of the user modal (Navbar).  
- This change ensures Chakra's styling system is used directly for the box-shadow, improving consistency and maintainability.

---

**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9395