### PR TITLE
Enable anonymous content for OnlyFor

### DIFF
--- a/src/components/MarkDownParser/MDComponents/index.jsx
+++ b/src/components/MarkDownParser/MDComponents/index.jsx
@@ -582,11 +582,12 @@ export function MDCheckbox({
 }
 
 export function OnlyForBanner({
-  children, permission, include, exclude, saas, withbanner,
+  children, permission, include, exclude, saas, withbanner, onlyAnonymous,
 }) {
   const allCapabilities = permission.split(',').concat(include.split(',').concat(exclude.split(',')));
 
   const parsedWithBanner = ['true', 'True', '1'].includes(String(withbanner));
+  const parsedOnlyAnonymous = ['true', 'True', '1'].includes(String(onlyAnonymous));
 
   return (
     <OnlyFor
@@ -594,6 +595,7 @@ export function OnlyForBanner({
       withBanner={parsedWithBanner}
       capabilities={allCapabilities}
       saas={saas}
+      onlyAnonymous={parsedOnlyAnonymous}
     >
       {children}
     </OnlyFor>
@@ -680,6 +682,7 @@ OnlyForBanner.propTypes = {
   exclude: PropTypes.string,
   saas: PropTypes.string,
   withbanner: PropTypes.string,
+  onlyAnonymous: PropTypes.string,
 };
 OnlyForBanner.defaultProps = {
   permission: '',
@@ -687,6 +690,7 @@ OnlyForBanner.defaultProps = {
   exclude: '',
   saas: '',
   withbanner: true,
+  onlyAnonymous: false,
 };
 DOMComponent.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/OnlyFor.jsx
+++ b/src/components/OnlyFor.jsx
@@ -40,9 +40,9 @@ function Component({ withBanner, children }) {
 }
 
 function OnlyFor({
-  academy, capabilities, children, onlyMember, onlyTeachers, withBanner, cohort, saas,
+  academy, capabilities, children, onlyMember, onlyTeachers, withBanner, cohort, saas, onlyAnonymous,
 }) {
-  const { user, hasNonSaasCohort } = useAuth();
+  const { user, hasNonSaasCohort, isAuthenticated } = useAuth();
   const academyNumber = Math.floor(academy);
   const teachers = ['TEACHER', 'ASSISTANT', 'REVIEWER'];
   const commonUser = ['TEACHER', 'ASSISTANT', 'STUDENT', 'REVIEWER', 'ADMIN'];
@@ -67,6 +67,20 @@ function OnlyFor({
 
   const isSaasAllowed = saas !== undefined;
   const isCohortSaas = currentCohort?.available_as_saas === true;
+
+  // If onlyAnonymous is true, hide content from authenticated users
+  if (onlyAnonymous && isAuthenticated) {
+    return (
+      <Component withBanner={withBanner}>
+        {children}
+      </Component>
+    );
+  }
+
+  // If onlyAnonymous is true and user is not authenticated, show content
+  if (onlyAnonymous && !isAuthenticated) {
+    return children;
+  }
 
   const haveRequiredCapabilities = () => {
     if (isSaasAllowed) {
@@ -122,6 +136,7 @@ OnlyFor.propTypes = {
   cohort: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.any])),
   withBanner: PropTypes.bool,
   saas: PropTypes.string,
+  onlyAnonymous: PropTypes.bool,
 };
 
 OnlyFor.defaultProps = {
@@ -132,6 +147,7 @@ OnlyFor.defaultProps = {
   cohort: null,
   withBanner: false,
   saas: undefined,
+  onlyAnonymous: false,
 };
 
 Component.propTypes = {


### PR DESCRIPTION
Add `onlyAnonymous` prop to `OnlyFor` component to hide content from authenticated users.

This allows content to be displayed exclusively to anonymous users, useful for public paths on static generated sites (e.g., `/lesson/<slug>`, `/interactive-coding-tutorial/<slug>`) to encourage sign-ups or show different content based on authentication status.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1ec6cb24-5413-4a85-b34b-4b2babfc3764) · [Cursor](https://cursor.com/background-agent?bcId=bc-1ec6cb24-5413-4a85-b34b-4b2babfc3764)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)