### PR TITLE
Feature: Generate and report referral coupon for new users after signup

### DIFF
--- a/src/hooks/useSignup.js
+++ b/src/hooks/useSignup.js
@@ -583,6 +583,16 @@ const useSignup = () => {
         }
       }
 
+      const couponData = await bc.payment().getMyCoupon();
+      if (couponData?.data?.length > 0) {
+        reportDatalayer({
+          dataLayer: {
+            event: 'plan_coupon_create',
+            coupon_data: couponData?.data[0],
+          },
+        });
+      }
+
       return transactionData;
     } catch (error) {
       console.error('Error handling payment bc.payment().pay', error);


### PR DESCRIPTION
#### What was done?
- Added logic to fetch and report a referral coupon (`getMyCoupon`) for the user after a successful signup/payment in the `useSignup` hook.
- When a new user registers, a referral coupon is created for them. This coupon is then reported to the datalayer with the `plan_coupon_create` event, so the user can invite others.

#### Why?
This enables the referral system by automatically generating a referral coupon for new users, making it easier for them to invite friends and track referrals.

#### How to test?
1. Register a new user and complete the signup/payment process.
2. Verify that a referral coupon is created for the user.
3. Check the datalayer to ensure the `plan_coupon_create` event is sent with the referral coupon data.

#### Additional notes
- The payment logic remains unchanged; the new logic only handles referral coupon creation and reporting after signup.
- No breaking changes detected.

**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9451