### PR TITLE
Added live event language to the workshop url

### DIFF
--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -309,7 +309,7 @@ function Navbar({ translations, pageProps }) {
                   borderRadius="md"
                   fontSize="sm"
                 >
-                  <NextLink href={`/workshops/${liveWorkshopData?.slug}`} passHref>
+                  <NextLink href={`/${liveWorkshopData?.language}/workshops/${liveWorkshopData?.slug}`} passHref>
                     <Box
                       display="inline-flex"
                       alignItems="center"


### PR DESCRIPTION
#### What was changed?
- Updated the live workshop badge URL to include language support: `/${liveWorkshopData?.language}/workshops/${liveWorkshopData?.slug}`

#### Why?
This ensures that users are redirected to the workshop page in the correct language based on the workshop's language setting.

#### How to test?
1. Verify that clicking the live workshop badge redirects to the localized URL (e.g., `/en/workshops/slug` or `/es/workshops/slug`)
2. Ensure the language in the URL matches the workshop's language setting

**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9534