### PR TITLE
Refactor checkout to use coupon from userSession instead of sessionStorage

### DIFF
--- a/src/context/SessionContext.jsx
+++ b/src/context/SessionContext.jsx
@@ -20,6 +20,8 @@ const initialUserSession = {
   internal_cta_placement: '',
   internal_cta_content: '',
   internal_cta_campaign: '',
+  ref: '',
+  coupon: '',
 };
 
 export const SessionContext = createContext({
@@ -87,6 +89,8 @@ function SessionProvider({ children }) {
       const internal_cta_placement = getQueryString('internal_cta_placement') || storedSession?.internal_cta_placement;
       const internal_cta_content = getQueryString('internal_cta_content') || storedSession?.internal_cta_content;
       const internal_cta_campaign = getQueryString('internal_cta_campaign') || storedSession?.internal_cta_campaign;
+      const ref = getQueryString('ref') || storedSession?.ref;
+      const coupon = getQueryString('coupon') || storedSession?.coupon;
 
       // remove translations for the endpoint
       const cleanedStore = {
@@ -109,6 +113,8 @@ function SessionProvider({ children }) {
         internal_cta_placement,
         internal_cta_content,
         internal_cta_campaign,
+        ref,
+        coupon,
       };
       setUserSession(session);
       localStorage.setItem('userSession', JSON.stringify(session));

--- a/src/pages/checkout/useCheckout.js
+++ b/src/pages/checkout/useCheckout.js
@@ -10,7 +10,6 @@ import signupAction from '../../store/actions/signupAction';
 import useSignup from '../../hooks/useSignup';
 import { BASE_PLAN, currenciesSymbols } from '../../utils/variables';
 import { reportDatalayer } from '../../utils/requests';
-import { usePersistentBySession } from '../../hooks/usePersistent';
 import useCustomToast from '../../hooks/useCustomToast';
 
 const useCheckout = () => {
@@ -46,7 +45,7 @@ const useCheckout = () => {
   const callbackUrl = getQueryString('callback');
   const planFormated = plan || BASE_PLAN;
 
-  const [coupon] = usePersistentBySession('coupon', '');
+  const coupon = userSession?.coupon || '';
 
   const couponValue = useMemo(() => {
     const formatedCouponQuery = couponQuery && couponQuery.replace(/[^a-zA-Z0-9-\s]/g, '');


### PR DESCRIPTION
### Summary

This PR updates the coupon handling logic in the checkout flow to ensure it is read from `localStorage` via `userSession`, instead of `sessionStorage`.

### Changes

* ✅ **SessionContext**

  * Added `coupon` and `ref` to the `initialUserSession` object.
  * Extracted `coupon` and `ref` from the query string and persisted them in `localStorage`.

* ✅ **useCheckout**

  * Removed the usage of `usePersistentBySession` for the `coupon`.
  * Now directly reads the coupon from `userSession` (which pulls from `localStorage`).
  * Cleaned up unused imports.

### Why?

Previously, the coupon was being stored in `localStorage` but read from `sessionStorage`, which caused inconsistencies in scenarios like:

* Page reloads
* Returning users resuming checkout

With this change:

* The coupon source is consistent.
* The logic is centralized in `SessionContext`.

### QA Steps

1. Visit `/checkout?coupon=REFERRAL4EV998MZ-16420`
2. Reload the page or return later.
3. Confirm the coupon is still applied correctly via the checkout logic.

**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9553