### PR TITLE
Added view mode in the url of the pricing view

### DIFF
--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -85,6 +85,14 @@ function PricingView() {
 
   const handleViewModeChange = (mode) => {
     setViewMode(mode);
+    // Update URL with view mode
+    router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        view: mode,
+      },
+    }, undefined, { shallow: true });
   };
 
   useEffect(() => {
@@ -92,8 +100,17 @@ function PricingView() {
       setViewMode('self-paced');
     } else {
       setViewMode('immersive-bootcamps');
+      if (!queryView) {
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            view: 'immersive-bootcamps',
+          },
+        }, undefined, { shallow: true });
+      }
     }
-  }, [queryView]);
+  }, [queryView, router]);
 
   useEffect(() => {
     if (previousViewMode !== viewMode) {


### PR DESCRIPTION
Issue: https://github.com/breatheco-de/breatheco-de/issues/9905

Ahora cuando un usuario entra a la vista de pricing, automaticamente a su url se le agrega un querystring view=[view_mode], por default es immersive-bootcamps. Tambien cuando cambia de vista entre self paced y bootcamps