### PR TITLE
Allow public portal pages when the asset is enabled in academy features

### DIFF
--- a/src/components/PublicPortalGate.jsx
+++ b/src/components/PublicPortalGate.jsx
@@ -25,7 +25,11 @@ function PublicPortalGate({
   const featureEnabled = feature && featureConfig
     ? isWhiteLabelFeatureEnabled(`public_portal.${feature}.enabled`)
     : publicPortalEnabled;
-  const isBlocked = isWhiteLabel && (alwaysHide || !publicPortalEnabled || !featureEnabled);
+  const isBlocked = isWhiteLabel && (
+    alwaysHide
+    || !featureEnabled
+    || (mode === 'login' && !publicPortalEnabled)
+  );
   const shouldRedirectToLogin = isBlocked && mode === 'login' && !isAuthenticated;
   const shouldShowPrivateContent = isBlocked && mode === 'login' && isAuthenticated;
 


### PR DESCRIPTION
Issue: https://github.com/breatheco-de/breatheco-de/issues/10777